### PR TITLE
Ignore bit-tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   "bugs": {
     "url": "https://github.com/donejs/place-my-order-assets/issues"
   },
-  "homepage": "https://github.com/donejs/place-my-order-assets"
+  "homepage": "https://github.com/donejs/place-my-order-assets",
+  "system": {
+    "bit-tabs/tabs.less!$less": "@empty"
+  }
 }


### PR DESCRIPTION
Since this package overrides the tabs behavior, we can simply just
ignore bit-tabs in this package, preventing the user from needing to do
so.
